### PR TITLE
[CLOSES #441] Use cash-market font for docs site

### DIFF
--- a/docs/gatsby-browser.js
+++ b/docs/gatsby-browser.js
@@ -1,0 +1,1 @@
+import "./src/styles/global.css"

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -1,0 +1,32 @@
+@font-face {
+  font-family: cash-market;
+  src: url("https://cash-f.squarecdn.com/static/fonts/cash-market/v2/CashMarket-Regular.woff2") format("woff2");
+  font-weight: 400;
+  font-style: normal
+}
+
+@font-face {
+  font-family: cash-market;
+  src: url("https://cash-f.squarecdn.com/static/fonts/cash-market/v2/CashMarket-Medium.woff2") format("woff2");
+  font-weight: 500;
+  font-style: normal
+}
+
+@font-face {
+  font-family: cash-market;
+  src: url("https://cash-f.squarecdn.com/static/fonts/cash-market/v2/CashMarket-Bold.woff2") format("woff2");
+  font-weight: 700;
+  font-style: normal
+}
+
+* {
+  font-family: cash-market,"Helvetica Neue",helvetica,sans-serif;
+}
+
+h1, h2 {
+  font-weight: 500;
+}
+
+li {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
* Followed Gatsby tutorial for styling: https://www.gatsbyjs.org/tutorial/part-two/