### PR TITLE
CI builds and release with Github Actions

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,18 @@
+name: Build-Docs
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [12]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install
+        run: cd docs && npm install
+      - name: Build
+        run: cd docs && npm run-script build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [10, 12, 13]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Misk-Web
+        run: sudo npm install -g @misk/cli
+      - name: Misk-Web Prebuild
+        run: miskweb prebuild -e
+      - name: Rush check for inconsistent dependency versions
+        run: node common/scripts/install-run-rush.js check
+      - name: Rush install
+        run: node common/scripts/install-run-rush.js update
+      - name: Rush build
+        run: node common/scripts/install-run-rush.js build --verbose
+      - name: miskweb new (using branch built CLI)
+        run: |
+          mkdir branch-cli-new-test && cd branch-cli-new-test
+          node ../packages/@misk/cli/lib/src/index.js new "Alpha Bravo" "alpha-bravo"

--- a/.github/workflows/new.yml
+++ b/.github/workflows/new.yml
@@ -1,0 +1,20 @@
+name: New
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [10, 12, 13]
+
+    steps:
+      - name: Install Misk-Web
+        run: sudo npm install -g @misk/cli
+      - name: miskweb new (using published CLI)
+        run: |
+          cd ..
+          mkdir release-cli-new-test && cd release-cli-new-test
+          miskweb new "Alpha Bravo" "alpha-bravo"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Alpha-Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [12]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Misk-Web
+        run: sudo npm install -g @misk/cli
+      - name: Misk-Web Prebuild
+        run: miskweb prebuild -e
+      - name: Rush check for inconsistent dependency versions
+        run: node common/scripts/install-run-rush.js check
+      - name: Rush install
+        run: node common/scripts/install-run-rush.js update
+      - name: Rush build
+        run: node common/scripts/install-run-rush.js build --verbose
+      - name: Rush bump version
+        run: node common/scripts/install-run-rush.js version --bump
+      - name: Rush publish
+        run: node common/scripts/install-run-rush.js publish --include-all -a -p -n ${NPM_PUBLISH_TOKEN}
+        env:
+          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/docs/refresh-external.sh
+++ b/docs/refresh-external.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "[WARN] This deploys the current local state of docs, consider a Rush rebuild!"
 
@@ -17,9 +17,9 @@ cat $MW/docs/README.md > $MW/docs/docs/guides/contributing-to-the-docs.md
 # Copy over tab demos
 declare -a tabs=("palette-exemplar" "palette-lts" "starter-basic")
 for tab in "${tabs[@]}"; do
-  DIR=$EXAMPLES/tabs/$tab/demo
-  mkdir -p $DIR
-  cp -r $MW/examples/tabs/$tab/lib/* $DIR
+    DIR=$EXAMPLES/tabs/$tab/demo
+    mkdir -p $DIR
+    cp -r $MW/examples/tabs/$tab/lib/* $DIR
 done
 
 # Copy over example data demo
@@ -29,7 +29,7 @@ cp -r $MW/examples/data/demo/* $DIR
 
 # Copy over documentation from @misk/* packages
 for dir in $MW/packages/@misk/*/; do
-  dir=${dir%*/}      # remove the trailing "/"
-  PKG=${dir##*/}    # print everything after the final "/"
-  cp $dir/*.md $MW/docs/docs/packages/$PKG/
+    dir=${dir%*/}      # remove the trailing "/"
+    PKG=${dir##*/}    # print everything after the final "/"
+    cp $dir/*.md $MW/docs/docs/packages/$PKG/
 done


### PR DESCRIPTION
Moving to Github Actions will provide easier publishing to NPM, we'll keep CircleCI builds around in case we need to switch back.