### PR TITLE
Fix null access of data.length and only showing table when 2+ rows

### DIFF
--- a/packages/@misk/core/src/features/Table/Component.tsx
+++ b/packages/@misk/core/src/features/Table/Component.tsx
@@ -8,8 +8,8 @@ export interface ITableProps {
 }
 
 export const Table = (props: ITableProps) => {
-  const { data, range = [0, data.length] } = props
-  if (data && data.length > 1) {
+  const { data, range = [0, data && data.length] } = props
+  if (data && data.length > 0) {
     /**
      * Data is loaded and ready to be rendered
      */


### PR DESCRIPTION
Encountered some rougher edges when using the `<Table />` component recently