### PR TITLE
Fix typo in npm command

### DIFF
--- a/docs/docs/guides/building-a-tab/00-getting-started.mdx
+++ b/docs/docs/guides/building-a-tab/00-getting-started.mdx
@@ -18,7 +18,7 @@ Here's how to build a tab that already exists.
 ```
 $ pwd
     /Users/dino/dev/dino-service/service/web/tabs/my-new-tab
-$ npm install -g @ misk/cli             # Install Misk-Web CLI
+$ npm install -g @misk/cli             # Install Misk-Web CLI
 $ miskweb ci-build              # ci-build command installs NPM dependencies and builds
 $ miskweb start               # start command starts Webpack Dev ...Server starts at port in miskTab.json...
 ...open browser to http://localhost:{port}...


### PR DESCRIPTION
Having a space after '@' makes npm produce an error.