### PR TITLE
Set context for admin dashboards

### DIFF
--- a/packages/@misk/core/src/components/TabLoaderComponent.tsx
+++ b/packages/@misk/core/src/components/TabLoaderComponent.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import React, { createContext } from "react"
 import { Helmet } from "react-helmet"
-import { IWebTab } from "src/utilities"
+import { IAdminDashboardConfig, IWebTab } from "src/utilities"
 
 /**
  * <TabLoaderComponent
@@ -10,6 +10,7 @@ import { IWebTab } from "src/utilities"
 
 export interface ITabLoaderProps {
   tabs: IWebTab[]
+  config: IAdminDashboardConfig
 }
 
 const RenderTab = (props: IWebTab) => {
@@ -23,14 +24,16 @@ const RenderTab = (props: IWebTab) => {
   )
 }
 
+export const AdminDashboardContext = createContext(null)
+
 export const TabLoaderComponent = (props: ITabLoaderProps): JSX.Element => {
   if (props.tabs) {
     return (
-      <>
+      <AdminDashboardContext.Provider value={props.config}>
         {props.tabs.map(tab => (
           <RenderTab key={tab.slug} {...tab} />
         ))}
-      </>
+      </AdminDashboardContext.Provider>
     )
   } else {
     return <div />

--- a/packages/@misk/core/src/features/Navbar/MiskContainer.tsx
+++ b/packages/@misk/core/src/features/Navbar/MiskContainer.tsx
@@ -139,7 +139,9 @@ export const MiskNavbarContainer = (
       />
       <ResponsiveAppContainer>
         {loadingSpinner && loading && <Spinner />}
-        <TabLoaderComponent tabs={dashboardMetadata.tabs} />
+        <TabLoaderComponent
+          tabs={dashboardMetadata.tabs}
+          config={dashboardMetadata.admin_dashboard_config} />
         {children}
       </ResponsiveAppContainer>
     </>

--- a/packages/@misk/core/src/utilities/interfaces.ts
+++ b/packages/@misk/core/src/utilities/interfaces.ts
@@ -17,11 +17,16 @@ export interface IDashboardTab extends IWebTab {
 
 export interface IAdminDashboardTab extends IDashboardTab {}
 
+export interface IAdminDashboardConfig {
+  protobuf_definition_url: string
+}
+
 export interface IDashboardMetadata {
   home_url: string
   navbar_items: Array<string | Element | JSX.Element>
   navbar_status: string | Element | JSX.Element
   tabs: IDashboardTab[]
+  admin_dashboard_config: IAdminDashboardConfig
 }
 
 export interface IServiceMetadata {


### PR DESCRIPTION
This PR takes the admin dashboard metadata introduced in https://github.com/cashapp/misk/pull/1881 and exposes it to child components of the `TabLoaderComponent` using a react context provider.

This context can be used by child components using a call to `useContext(AdminDashboardContext)`

