### PR TITLE
Ensure parseOnChangeArgs handles null

### DIFF
--- a/packages/@misk/simpleredux/src/utilities/handler.ts
+++ b/packages/@misk/simpleredux/src/utilities/handler.ts
@@ -25,6 +25,7 @@ export interface IHandlerOptions extends IDispatchOptions {
 export const isSyntheticEvent = (obj: any): boolean => {
   if (
     typeof obj === "object" &&
+    obj !== null &&
     "nativeEvent" in obj &&
     "currentTarget" in obj &&
     "target" in obj &&
@@ -52,10 +53,12 @@ export const isSyntheticEvent = (obj: any): boolean => {
  * @param args array of any event input from a component onChange function
  */
 export const parseOnChangeArgs = (args: any) => {
-  if (args[0] && args[0].target && args[0].target.value) {
+  if (!args) {
+    return null
+  } else if (args[0] && args[0].target && args[0].target.value) {
     // onChange=(event: [{ target: { value: any } }] ) => ... }
     return args[0].target.value
-  } else if (args && args.target && args.target.value) {
+  } else if (args.target && args.target.value) {
     // onChange={(value: number) => ... }
     return args.target.value
   } else if (

--- a/packages/@misk/simpleredux/tests/utilities/handler.test.ts
+++ b/packages/@misk/simpleredux/tests/utilities/handler.test.ts
@@ -30,6 +30,9 @@ describe("isSyntheticEvent", () => {
   it("false if not SyntheticEvent", () => {
     expect(isSyntheticEvent(1234)).toBeFalsy()
   })
+  it("false if null", () => {
+    expect(isSyntheticEvent(null)).toBeFalsy()
+  })
 })
 
 describe("parseOnChangeArgs handles all components onChange inputs", () => {
@@ -45,6 +48,12 @@ describe("parseOnChangeArgs handles all components onChange inputs", () => {
   it("<DateInput /> onChange selectedDate, isUserChange", () => {
     const now = new Date()
     expect(parseOnChangeArgs([now, false])).toEqual(now)
+  })
+  it("<DateInput /> clear onChange selectedDate, isUserChange", () => {
+    expect(parseOnChangeArgs([null, true])).toEqual([null, true])
+  })
+  it("<DateInput /> null onChange selectedDate, isUserChange", () => {
+    expect(parseOnChangeArgs(null)).toEqual(null)
   })
   it("<TagInput /> onChange values: string[]", () => {
     expect(parseOnChangeArgs(["alpha", "bravo", "charlie"])).toEqual([


### PR DESCRIPTION
This PR fixes the following error:
<img width="722" alt="image" src="https://user-images.githubusercontent.com/1909544/191570704-0588bf59-ec99-4570-b789-161030cea996.png">

This occurs when attempting to set a value to null via `simpleMergeData`. 