### PR TITLE
Run rush update on renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,5 +17,13 @@
     "**/__tests__/**",
     "**/tests/**"
   ],
-  "stabilityDays": 3
+  "stabilityDays": 3,
+  "postUpgradeTasks": {
+        "commands": [
+            "node common/scripts/install-run-rush.js update"
+        ],
+        "fileFilters": [
+            "common/config/rush/pnpm-lock.yaml"
+        ]
+    }
 }


### PR DESCRIPTION
Related to https://github.com/cashapp/misk-web/pull/1849
Renovate docs: https://docs.renovatebot.com/configuration-options/#postupgradetasks

This PR attempts to fix our renovate configuration to run `rush update` when making dependency changes. This will prevent cases such as the above where the lock file wasn't updated by renovate, requiring another PR. 