### PR TITLE
Node 17 -> 18 for builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14, 16, 17]
+        node: [14, 16, 18]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/new.yml
+++ b/.github/workflows/new.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14, 16, 17]
+        node: [14, 16, 18]
 
     steps:
       - name: Install Misk-Web


### PR DESCRIPTION
Node 17 is EOL: https://github.com/nodejs/release#release-schedule, let's use 18 since it's the next LTS release anyways. 