### PR TITLE
Remove webpack hot option

### DIFF
--- a/packages/@misk/dev/webpack.config.tab.js
+++ b/packages/@misk/dev/webpack.config.tab.js
@@ -107,7 +107,6 @@ module.exports = (env, argv) => {
     devServer: {
       host: "0.0.0.0",
       port: port,
-      hot: true,
       historyApiFallback: true
     },
     module: {


### PR DESCRIPTION
<img width="874" alt="image" src="https://user-images.githubusercontent.com/1909544/196489015-7816dc45-e3f5-457a-83b3-d4b3aad45387.png">

This flag is needed explicitly anymore, so we can remove it! 